### PR TITLE
Fixed the Check Report bug

### DIFF
--- a/src/Client/RestClient.php
+++ b/src/Client/RestClient.php
@@ -273,26 +273,23 @@ class RestClient
         $body = (string) ($response->getBody());
         $check_json = json_decode($body, true);
 
+        $check = new Check($check_json['id'],
+            $check_json['created_at'],
+            $check_json['href'],
+            $check_json['type'],
+            $check_json['status'],
+            $check_json['result']);
+
         if ($load_reports === true)
         {
-            $reports = [];
             $report_factory = new ReportFactory();
 
             foreach ($check_json['reports'] as $report_data)
             {
-                $report_id = $report_data['id'];
                 $report = $report_factory->createReport($report_data);
-                $reports[$report_id] = $report;
+                $check->addReport($report);
             }
         }
-
-        $check = new Check($check_json['id'],
-                           $check_json['created_at'],
-                           $check_json['href'],
-                           $check_json['type'],
-                           $check_json['status'],
-                           $check_json['result'],
-                           $reports);
 
         return $check;
     }


### PR DESCRIPTION
I noticed that reports were being added onto the `Check` object in the constructor, but the `Check` constructor has no provision for this (demonstrated below)

```php
$check = new Check($id, $created_at, $href, $type, $status, $result, $reports)

public function __construct($id, $created_at, $href, $type, $status, $result) {
```

It meant that you could not retrieve reports from the `Check` object, since the reports themselves weren't added the the `reports` property on the object via `$this->reports = $reports`.

I've resolved this issue now, using your own `addReports` method to push each report onto the `Check` object after they have been created.